### PR TITLE
Enables array srcdir in whiteboard.toml

### DIFF
--- a/src/toml_format.h
+++ b/src/toml_format.h
@@ -19,10 +19,19 @@ typedef struct package {
 void make_package(package_t *self, toml_table_t *toml);
 package_t init_package();
 
+typedef struct sources {
+	bool is_array;
+	union {
+		char *single;
+		// vector_t of char* source dirs
+		vector_t multi;
+	};
+} sources_t;
+
 typedef struct bin {
     bool default_bin;
     char *name;
-    char *srcdir;
+    sources_t srcdir;
     char *includedir;
     char *targetdir;
     char *programincludedir;


### PR DESCRIPTION
For example if you have the directory structure:
```
src/main.c
src/a/dep1.c
src/b/dep2.c
```
Previously, `srcdir = "src/"` would only compile `src/main.c`. But now, you can do `srcdir = ["src/", "src/a/", "src/b/"]` and it will include all three source files in the build. This does not require `srcdir` to be an array for single-source-directory inputs. From my testing, `srcdir = "src/"` works just as well as `srcdir = ["src/"]`.